### PR TITLE
Fixed reading bits in decoder

### DIFF
--- a/src/main/resources/Decoder.edt
+++ b/src/main/resources/Decoder.edt
@@ -52,6 +52,9 @@ public class %decoder_class% implements Decoder {
      * @return the bits read
      */
     private byte read(int start, int length) {
+        if (length > 8) {
+            throw new IllegalArgumentException("length must be <= 8 bits");
+        }
         if (start + length > 8 * bytesRead) {
             instructionBytes[bytesRead++] = ((Short) memory.read(memoryPosition++)).byteValue();
         }
@@ -63,6 +66,10 @@ public class %decoder_class% implements Decoder {
         int endByte = (start + length) / 8;
         int endOffset = (startOffset + length) % 8;
         byte endMask = (byte) (0xFF << (8 - endOffset));
+
+        if (startByte == endByte) {
+            return (byte)((instructionBytes[startByte] & startMask & endMask) >>> (8 - endOffset));
+        }
         
         byte result = (byte) ((instructionBytes[startByte] & startMask) << endOffset);
         return (byte) (result | (instructionBytes[endByte] & endMask) >>> (8 - endOffset));


### PR DESCRIPTION
For example, `read(2,3)` for `11011111` did not return `011`.

```
a = 11011111 & 00111111 << 2 = 01111100
b = 11011111 & 11111000 >> 3 = 00011011
```

You cannot do `result = (a | b)` if you operate on the same byte, only if `start+length > 8`.

```
read(6,3):
a = 11011111 & 00000011 << 1 = 00000110
b = 00000000 & 10000000 >> 7 = 00000000
```
`result = a|b`, correct.