### PR TITLE
[#17] Correct number of bits to read in the last byte

### DIFF
--- a/src/main/resources/Decoder.edt
+++ b/src/main/resources/Decoder.edt
@@ -84,9 +84,14 @@ public class %decoder_class% implements Decoder {
     private byte[] getValue(int start, int length) {
         int byteCount = (length - 1) / 8 + 1;
         byte[] result = new byte[byteCount];
-        
+
+        int lastByteLength = length % 8;
+        if (lastByteLength == 0) {
+            lastByteLength = 8;
+        }
+
         for (int i = 0; i < byteCount; i++) {
-            int bits = (i != byteCount - 1) ? 8 : length % 8;
+            int bits = (i == byteCount - 1) ? lastByteLength : 8;
             result[i] = read(start, bits);
             start += 8;
         }

--- a/src/main/resources/Disassembler.edt
+++ b/src/main/resources/Disassembler.edt
@@ -4,6 +4,7 @@ package %disasm_package%;
 import static %decoder_name%.*;
 import emulib.plugins.cpu.*;
 import emulib.plugins.memory.MemoryContext;
+import emulib.runtime.RadixUtils;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -177,10 +178,9 @@ public class %disasm_class% extends AbstractDisassembler {
             case 's':
                 return new String(value);
             case 'x':
-                String formatString = "%0" + 2 * value.length + "x";
-                return String.format(formatString, new BigInteger(value));
+                return RadixUtils.convertToRadix(value, 16, !LITTLE_ENDIAN).toLowerCase();
             case 'X':
-                return format('x', value).toUpperCase();
+                return RadixUtils.convertToRadix(value, 16, !LITTLE_ENDIAN);
             case '%':
                 return "%";
             default:

--- a/src/main/resources/Disassembler.edt
+++ b/src/main/resources/Disassembler.edt
@@ -143,7 +143,7 @@ public class %disasm_class% extends AbstractDisassembler {
             if (value == null) {
                 value = instruction.getString(ruleCode).getBytes();
             }
-            
+
             String replaced = format(mnemonic.charAt(position + 1), value); 
             mnemonic.replace(position, position += 2, replaced);
         }


### PR DESCRIPTION
All instructions using numbers, both 8 bit or 16 bit, have not disassembled the low-order byte. For example:

cpi 55h
is disassembled as

cpi 00
However, the opcode is correct (FE 55)

EDIT: Added fix for #19 